### PR TITLE
Restore Relay 8.5 test

### DIFF
--- a/src/Symfony/Component/Semaphore/Tests/Store/RelayStoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/RelayStoreTest.php
@@ -25,10 +25,6 @@ class RelayStoreTest extends AbstractRedisStoreTestCase
 
     public static function setUpBeforeClass(): void
     {
-        if (\PHP_VERSION_ID <= 80500 && isset($_SERVER['GITHUB_ACTIONS'])) {
-            self::markTestSkipped('Test segfaults on PHP 8.5');
-        }
-
         try {
             new Relay(...explode(':', getenv('REDIS_HOST')));
         } catch (\Relay\Exception $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.3 for features / 6.4, and 7.2 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | https://github.com/symfony/symfony/pull/59846
| License       | MIT

This test was disabled, but can now be restored against PHP 8.5.